### PR TITLE
Reduce dependency to command-line man2html

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Build-Depends:
  hdf5-helpers,
  libfreeipmi-dev,
  libhdf5-dev,
- man2html,
+ man2html-base,
  libcurl4-openssl-dev,
  libpmix-dev,
  libhttp-parser-dev,


### PR DESCRIPTION
man2html tries to pull in apache2 because it publishes all the HTMLified manpages in a subdirectory.

The build process only needs the command line `man2html` tool, provided by `man2html-base`